### PR TITLE
Enable CORS for frontend

### DIFF
--- a/Scarlet.Comet.Api/Program.cs
+++ b/Scarlet.Comet.Api/Program.cs
@@ -5,6 +5,17 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllers();
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.WithOrigins("http://localhost:3000")
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+    });
+});
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -21,6 +32,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors();
 
 app.MapControllers();
 


### PR DESCRIPTION
Added CORS configuration to allow the React frontend at http://localhost:3000 to access the backend API endpoints.