### PR TITLE
Add Auth0 authorization for catalog delete

### DIFF
--- a/Scarlet.Comet.Api/Controllers/CatalogController.cs
+++ b/Scarlet.Comet.Api/Controllers/CatalogController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Scarlet.Comet.Data;
@@ -78,7 +79,8 @@ public class CatalogController : ControllerBase
         return NoContent();
     }
 
-    [HttpDelete("{id:int}")]
+   [HttpDelete("{id:int}")]
+[Authorize("delete:catalog")]
 public ActionResult DeleteItem(int id)
 {
     var item = _context.Items

--- a/Scarlet.Comet.Api/Program.cs
+++ b/Scarlet.Comet.Api/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Scarlet.Comet.Data;
 
@@ -14,6 +15,22 @@ builder.Services.AddCors(options =>
             .AllowAnyHeader()
             .AllowAnyMethod();
     });
+});
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.Authority = builder.Configuration["Auth0:Authority"];
+    options.Audience = builder.Configuration["Auth0:Audience"];
+});
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("delete:catalog", policy =>
+        policy.RequireClaim("permissions", "delete:catalog"));
 });
 
 builder.Services.AddEndpointsApiExplorer();
@@ -34,6 +51,10 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseCors();
+
+app.UseAuthentication();
+
+app.UseAuthorization();
 
 app.MapControllers();
 

--- a/Scarlet.Comet.Api/Scarlet.Comet.Api.csproj
+++ b/Scarlet.Comet.Api/Scarlet.Comet.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Scarlet.Comet.Api/appsettings.json
+++ b/Scarlet.Comet.Api/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "Auth0": {
+    "Authority": "https://dev-6y8gpkxm4f02t2v3.us.auth0.com/",
+    "Audience": "https://api.scarlet-comet.com"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Added Auth0 JWT Bearer authentication to the API. Configured Authority and Audience in appsettings.json, added an authorization policy for delete:catalog, and protected the Catalog DELETE endpoint with that policy.