### PR TITLE
Configure API to use Azure SQL

### DIFF
--- a/Scarlet.Comet.Api/Program.cs
+++ b/Scarlet.Comet.Api/Program.cs
@@ -36,8 +36,10 @@ builder.Services.AddAuthorization(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+var connectionString = builder.Configuration.GetConnectionString("StoreConnection");
+
 builder.Services.AddDbContext<StoreContext>(options =>
-    options.UseSqlite("Data Source=Store.db"));
+    options.UseSqlServer(connectionString));
 
 var app = builder.Build();
 

--- a/Scarlet.Comet.Api/Scarlet.Comet.Api.csproj
+++ b/Scarlet.Comet.Api/Scarlet.Comet.Api.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Scarlet.Comet.Api/appsettings.json
+++ b/Scarlet.Comet.Api/appsettings.json
@@ -3,6 +3,9 @@
     "Authority": "https://dev-6y8gpkxm4f02t2v3.us.auth0.com/",
     "Audience": "https://api.scarlet-comet.com"
   },
+  "ConnectionStrings": {
+    "StoreConnection": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Added SQL Server support and updated the API to read the StoreConnection connection string from configuration. The actual Azure SQL connection string is stored in Azure App Service environment variables, not in source control.